### PR TITLE
Rename generators to coroutines and put them behind a cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 description = "Python-like list comprehensions for standard containers"
 categories = ["rust-patterns"]
-keywords = ["vector", "comprehension", "macro", "generator", "python"]
+keywords = ["vector", "comprehension", "macro", "coroutine", "python"]
 repository = "https://github.com/nickeb96/mapcomp"
 documentation = "https://docs.rs/mapcomp"
 
@@ -15,3 +15,9 @@ documentation = "https://docs.rs/mapcomp"
 travis-ci = { repository = "nickeb96/mapcomp" }
 
 [dependencies]
+
+[features]
+coroutines = []
+
+[package.metadata.docs.rs]
+features = ["coroutines"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ containers:
 - `BTreeMap`
 - `BTreeSet`
 
-Also provides another macro for generator comprehension.
+Also provides another macro for coroutine comprehension.
 
 For more info please read the [documentation here](https://docs.rs/mapcomp).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! Macros for container comprehensions similar to Python's list comprehension.
 //!
-//! This crate adds vector, set, map, and generator comprehensions.  It is
+//! This crate adds vector, set, map, and coroutine comprehensions.  It is
 //! meant to complement [maplit](https://docs.rs/maplit/) which provides
 //! macro literals for the same standard containers.
 //!
@@ -18,7 +18,7 @@
 //!
 //! The macro names are the same as maplit's container literal macros but with
 //! a **c** at the end for **c**omprehension.  There is an additional macro
-//! `iterc!()` for creating lazily evaluated generator expressions.
+//! `iterc!()` for creating lazily evaluated coroutine expressions.
 //!
 //! List comprehensions exist [in many languages](https://en.wikipedia.org/wiki/List_comprehension)
 //! and in many styles.  This crate uses the same syntax as Python's list
@@ -45,110 +45,122 @@
 //! # }
 //! ```
 
-#![feature(coroutines, coroutine_trait, arbitrary_self_types)]
+#![cfg_attr(
+    feature = "coroutines",
+    feature(coroutines, coroutine_trait, stmt_expr_attributes)
+)]
 
-/// This is an implementation detail used by `iterc!()` and it should not be
-/// directly instantiated.
+#[cfg(feature = "coroutines")]
 #[doc(hidden)]
-pub struct GeneratorIterator<G: ::std::ops::Coroutine + ::std::marker::Unpin> {
-    generator: G,
-}
-
-impl<G: ::std::ops::Coroutine + ::std::marker::Unpin> GeneratorIterator<G> {
-    pub fn new(generator: G) -> GeneratorIterator<G> {
-        GeneratorIterator { generator }
+pub mod iterator_comprehension {
+    /// This is an implementation detail used by `iterc!()` and it should not be
+    /// directly instantiated.
+    #[doc(hidden)]
+    pub struct CoroutineIterator<C: ::std::ops::Coroutine + ::std::marker::Unpin> {
+        coroutine: C,
     }
-}
 
-impl<G: ::std::ops::Coroutine + ::std::marker::Unpin> Iterator for GeneratorIterator<G> {
-    type Item = G::Yield;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        use ::std::ops::CoroutineState;
-        match ::std::pin::Pin::new(&mut self.generator).resume(()) {
-            CoroutineState::Yielded(y) => Some(y),
-            _ => None,
+    impl<C: ::std::ops::Coroutine + ::std::marker::Unpin> CoroutineIterator<C> {
+        pub fn new(coroutine: C) -> CoroutineIterator<C> {
+            CoroutineIterator { coroutine }
         }
     }
-}
 
-/// Iterator Comprehension
-///
-/// Returns an iterator over the contents of the comprehension.  It is
-/// analogous to [Python's generator comprehensions](https://www.python.org/dev/peps/pep-0289/).
-/// Syntactically, it is similar to the `vecc![]` macro but it returns a lazily
-/// evaluated iterator instead of a container.  It's use requires the experimental
-/// generators feature.
-///
-/// ```rust
-/// #![feature(generators, generator_trait)]
-/// #[macro_use]
-/// extern crate mapcomp;
-///
-/// # fn main() {
-/// let numbers = [8, 3, 5, 7];
-///
-/// let mut powers_of_two = iterc!(1 << x; for x in &numbers);
-///
-/// assert_eq!(Some(256), powers_of_two.next());
-/// assert_eq!(Some(8), powers_of_two.next());
-/// assert_eq!(Some(32), powers_of_two.next());
-/// assert_eq!(Some(128), powers_of_two.next());
-/// assert_eq!(None, powers_of_two.next());
-/// # }
-/// ```
-///
-/// Since it only creates an iterator and not a fully populated container, the
-/// comprehension can be created over an unbounded or infinite iterator.
-///
-/// ```rust
-/// # #![feature(generators, generator_trait)]
-/// # #[macro_use] extern crate mapcomp;
-/// # fn main() {
-/// let mut odd_squares = iterc!(x * x; for x in 1..; if x % 2 == 1);
-///
-/// assert_eq!(Some(1), odd_squares.next());
-/// assert_eq!(Some(9), odd_squares.next());
-/// assert_eq!(Some(25), odd_squares.next());
-/// assert_eq!(Some(49), odd_squares.next());
-/// # }
-/// ```
-#[macro_export]
-macro_rules! iterc {
-    (@__ $exp:expr; for $item:pat in $iter:expr; if $cond:expr) => (
-        for $item in $iter {
-            if $cond {
+    impl<C: ::std::ops::Coroutine + ::std::marker::Unpin> Iterator for CoroutineIterator<C> {
+        type Item = C::Yield;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            use ::std::ops::CoroutineState;
+            match ::std::pin::Pin::new(&mut self.coroutine).resume(()) {
+                CoroutineState::Yielded(y) => Some(y),
+                _ => None,
+            }
+        }
+    }
+
+    /// Iterator Comprehension
+    ///
+    /// Returns an iterator over the contents of the comprehension.  It is
+    /// analogous to [Python's generator comprehensions](https://www.python.org/dev/peps/pep-0289/).
+    /// Syntactically, it is similar to the `vecc![]` macro but it returns a lazily
+    /// evaluated iterator instead of a container.  It's use requires the experimental
+    /// coroutines feature.
+    ///
+    #[cfg_attr(
+        feature = "coroutines",
+        doc = r##"
+```rust
+#![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+#[macro_use]
+extern crate mapcomp;
+
+# fn main() {
+let numbers = [8, 3, 5, 7];
+
+let mut powers_of_two = iterc!(1 << x; for x in &numbers);
+
+assert_eq!(Some(256), powers_of_two.next());
+assert_eq!(Some(8), powers_of_two.next());
+assert_eq!(Some(32), powers_of_two.next());
+assert_eq!(Some(128), powers_of_two.next());
+assert_eq!(None, powers_of_two.next());
+# }
+```
+
+Since it only creates an iterator and not a fully populated container, the
+comprehension can be created over an unbounded or infinite iterator.
+
+```rust
+# #![feature(coroutines, coroutine_trait, stmt_expr_attributes)]
+# #[macro_use] extern crate mapcomp;
+# fn main() {
+let mut odd_squares = iterc!(x * x; for x in 1..; if x % 2 == 1);
+
+assert_eq!(Some(1), odd_squares.next());
+assert_eq!(Some(9), odd_squares.next());
+assert_eq!(Some(25), odd_squares.next());
+assert_eq!(Some(49), odd_squares.next());
+# }
+```
+"##
+    )]
+    #[macro_export]
+    macro_rules! iterc {
+        (@__ $exp:expr; for $item:pat in $iter:expr; if $cond:expr) => (
+            for $item in $iter {
+                if $cond {
+                    yield $exp;
+                }
+            }
+        );
+
+        (@__ $exp:expr; for $item:pat in $iter:expr) => (
+            for $item in $iter {
                 yield $exp;
             }
-        }
-    );
+        );
 
-    (@__ $exp:expr; for $item:pat in $iter:expr) => (
-        for $item in $iter {
-            yield $exp;
-        }
-    );
+        (@__ $exp:expr; for $item:pat in $iter:expr; if $cond:expr; $($tail:tt)+) => (
+            for $item in $iter {
+                if $cond {
+                    iterc!(@__ $exp; $($tail)+)
+                }
+            }
+        );
 
-    (@__ $exp:expr; for $item:pat in $iter:expr; if $cond:expr; $($tail:tt)+) => (
-        for $item in $iter {
-            if $cond {
+        (@__ $exp:expr; for $item:pat in $iter:expr; $($tail:tt)+) => (
+            for $item in $iter {
                 iterc!(@__ $exp; $($tail)+)
             }
-        }
-    );
+        );
 
-    (@__ $exp:expr; for $item:pat in $iter:expr; $($tail:tt)+) => (
-        for $item in $iter {
-            iterc!(@__ $exp; $($tail)+)
-        }
-    );
-
-    ($exp:expr; $($tail:tt)+) => ({
-        let mut generator = || {
-            iterc!(@__ $exp; $($tail)+)
-        };
-        ::mapcomp::GeneratorIterator::new(generator)
-    });
+        ($exp:expr; $($tail:tt)+) => ({
+            let mut coroutine = #[coroutine] || {
+                iterc!(@__ $exp; $($tail)+)
+            };
+            ::mapcomp::iterator_comprehension::CoroutineIterator::new(coroutine)
+        });
+    }
 }
 
 /// Vector Comprehension

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-
 //! Macros for container comprehensions similar to Python's list comprehension.
 //!
 //! This crate adds vector, set, map, and generator comprehensions.  It is
@@ -46,36 +45,32 @@
 //! # }
 //! ```
 
-
-#![feature(generators, generator_trait, arbitrary_self_types)]
-
+#![feature(coroutines, coroutine_trait, arbitrary_self_types)]
 
 /// This is an implementation detail used by `iterc!()` and it should not be
 /// directly instantiated.
 #[doc(hidden)]
-pub struct GeneratorIterator<G: ::std::ops::Generator + ::std::marker::Unpin> {
+pub struct GeneratorIterator<G: ::std::ops::Coroutine + ::std::marker::Unpin> {
     generator: G,
 }
 
-impl<G: ::std::ops::Generator + ::std::marker::Unpin> GeneratorIterator<G> {
+impl<G: ::std::ops::Coroutine + ::std::marker::Unpin> GeneratorIterator<G> {
     pub fn new(generator: G) -> GeneratorIterator<G> {
         GeneratorIterator { generator }
     }
 }
 
-impl<G: ::std::ops::Generator + ::std::marker::Unpin> Iterator for GeneratorIterator<G> {
+impl<G: ::std::ops::Coroutine + ::std::marker::Unpin> Iterator for GeneratorIterator<G> {
     type Item = G::Yield;
 
     fn next(&mut self) -> Option<Self::Item> {
-        use ::std::ops::GeneratorState;
+        use ::std::ops::CoroutineState;
         match ::std::pin::Pin::new(&mut self.generator).resume(()) {
-            GeneratorState::Yielded(y) => Some(y),
+            CoroutineState::Yielded(y) => Some(y),
             _ => None,
         }
     }
 }
-
-
 
 /// Iterator Comprehension
 ///
@@ -156,8 +151,6 @@ macro_rules! iterc {
     });
 }
 
-
-
 /// Vector Comprehension
 ///
 /// Creates a new `Vec` from the contents of the comprehension.  Vector
@@ -178,7 +171,7 @@ macro_rules! iterc {
 /// let items = [4, 7, 2];
 ///
 /// let even_squares = vecc![x*x; for x in &items; if x % 2 == 0];
-/// 
+///
 /// assert_eq!(even_squares, vec![16, 4]);
 /// # }
 /// ```
@@ -218,8 +211,6 @@ macro_rules! vecc {
         ret
     });
 }
-
-
 
 /// Hash Set Comprehension
 ///
@@ -284,8 +275,6 @@ macro_rules! hashsetc {
         ret
     });
 }
-
-
 
 /// Hash Map Comprehension
 ///
@@ -352,8 +341,6 @@ macro_rules! hashmapc {
     });
 }
 
-
-
 /// BTree Set Comprehension
 ///
 /// Creates a `BTreeSet` from the contents of the comprehension.  Same syntax as
@@ -408,8 +395,6 @@ macro_rules! btreesetc {
         ret
     });
 }
-
-
 
 /// BTree Map Comprehension
 ///
@@ -472,4 +457,3 @@ mod tests {
         let _v = vecc![x * x; for x in 1..10; if x % 2 == 0];
     }
 }
-


### PR DESCRIPTION
The unstable feature got renamed so this fixes it :)

This also puts the `iterc` macro behind a cargo feature so that users only have to use nightly when they absolutely need it.